### PR TITLE
Adding support for intermediate run start points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [1.21.1] - 2021-07-21
 - Added support for intermediate run start points #1
+- --dbfile is added to generate the test-list and then run tests on the target and reference
 - --testfile is added to directly run tests on the target and reference (assumes the testlist has been correctly generated)
 - --no-ref-run is added so that tests do not run on reference and quit before signature comparison
 - --no-dut-run is added so that tests do not run on DUT and quit before signature comparison 
+- Added a timestamp comment on the generated database.yaml and testlist.yaml files
 
 ## [1.21.0] - 2021-07-21
 - Changed CI script from gitlab to github actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.21.1] - 2021-07-21
+## [1.21.1] - 2021-07-24
 - Added support for intermediate run start points #1
 - --dbfile is added to generate the test-list and then run tests on the target and reference
 - --testfile is added to directly run tests on the target and reference (assumes the testlist has been correctly generated)
 - --no-ref-run is added so that tests do not run on reference and quit before signature comparison
 - --no-dut-run is added so that tests do not run on DUT and quit before signature comparison 
 - Added a timestamp comment on the generated database.yaml and testlist.yaml files
+- Change FXLEN macro to FLEN #8
 
 ## [1.21.0] - 2021-07-21
 - Changed CI script from gitlab to github actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.1] - 2021-07-21
+- Added support for intermediate run start points #1
+- --testfile is added to directly run tests on the target and reference (assumes the testlist has been correctly generated)
+- --no-ref-run is added so that tests do not run on reference and quit before signature comparison
+- --no-dut-run is added so that tests do not run on DUT and quit before signature comparison 
+
 ## [1.21.0] - 2021-07-21
 - Changed CI script from gitlab to github actions
 - Removing hosted cgf files

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -160,6 +160,10 @@ Optional arguments from the cli:
   ``./riscof_work``
 - no-browser: when used, RISCOF skips automatically opening the html report in the default web
   browser.
+- dbfile: The path to the database file, from which testlist will be generated 
+- testfile: The path to the testlist file on which tests will be run
+- no-ref-run: when used, RISCOF will not run tests on Reference and will quit before signatures comparison
+- no-dut-run: when used, RISCOF will not run tests on DUT and will quit before signatures comparison 
 
 All artifacts of this command are generated in the ``work_dir`` directory. Typicall artifacts will
 include:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -267,17 +267,22 @@ Once you have installed RISCOF you can execute ``riscof --help`` to print the he
     	  -h, --help       show this help message and exit
     	
     Action 'run'
-    
-    	usage: riscof run [-h] [--config PATH] --suite PATH --env PATH [--no-browser]
-    	                  [--work-dir PATH]
-    	
-    	optional arguments:
-    	  --config PATH    The Path to the config file. [Default=./config.ini]
-    	  --env PATH       The Path to the custom env directory.
-    	  --no-browser     Do not open the browser for showing the test report.
-    	  --suite PATH     The Path to the custom suite directory.
-    	  --work-dir PATH  The Path to the work-dir.
-    	  -h, --help       show this help message and exit
+
+	usage: riscof run [-h] [--config PATH] --suite PATH --env PATH [--no-browser] [--work-dir PATH] [--dbfile PATH | --testfile PATH]
+	                  [--no-ref-run] [--no-dut-run]
+	
+	optional arguments:
+	  --config PATH    The Path to the config file. [Default=./config.ini]
+	  --dbfile PATH    The Path to the database file.
+	  --env PATH       The Path to the custom env directory.
+	  --no-browser     Do not open the browser for showing the test report.
+	  --no-dut-run     Do not run tests on DUT
+	  --no-ref-run     Do not run tests on Reference
+	  --suite PATH     The Path to the custom suite directory.
+	  --testfile PATH  The Path to the testlist file.
+	  --work-dir PATH  The Path to the work-dir.
+	  -h, --help       show this help message and exit
+
     	
     Action 'testlist'
     

--- a/riscof/Templates/setup/model/riscof_model.py
+++ b/riscof/Templates/setup/model/riscof_model.py
@@ -75,6 +75,8 @@ class dutname(pluginTemplate):
         # build your RTL here
 
     def runTests(self, testList, cgf_file=None):
+        if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
         make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
         make.makeCommand = 'make -j' + self.num_jobs
         for file in testList:

--- a/riscof/Templates/setup/reference/riscof_model.py
+++ b/riscof/Templates/setup/reference/riscof_model.py
@@ -79,6 +79,8 @@ class refname(pluginTemplate):
         # build your RTL here
 
     def runTests(self, testList, cgf_file=None):
+        if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
         make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
         make.makeCommand = self.make + ' -j' + self.num_jobs
         for file in testList:

--- a/riscof/Templates/setup/sail_cSim/riscof_sail_cSim.py
+++ b/riscof/Templates/setup/sail_cSim/riscof_sail_cSim.py
@@ -80,6 +80,8 @@ class sail_cSim(pluginTemplate):
 
 
     def runTests(self, testList, cgf_file=None):
+        if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
         make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
         make.makeCommand = self.make + ' -j' + self.num_jobs
         for file in testList:

--- a/riscof/__init__.py
+++ b/riscof/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '1.21.0'
+__version__ = '1.21.1'

--- a/riscof/dbgen.py
+++ b/riscof/dbgen.py
@@ -3,6 +3,8 @@ import os
 import git
 import sys
 import re
+import pytz
+from datetime import datetime
 from riscof.utils import yaml
 import riscof.utils as utils
 import collections
@@ -189,5 +191,6 @@ def generate():
                 continue
             db[fpath] = {'commit_id': '-', **temp}
     with open(dbfile, "w") as wrfile:
+        wrfile.write('# database generated on ' + (datetime.now(pytz.timezone('GMT'))).strftime("%Y-%m-%d %H:%M GMT")+'\n')
         yaml.dump(orderdict(db),
                   wrfile)

--- a/riscof/framework/main.py
+++ b/riscof/framework/main.py
@@ -151,7 +151,7 @@ def run_coverage(base, dut_isa_spec, dut_platform_spec, work_dir, cgf_file=None)
 
     return results, for_html, test_stats, coverpoints
 
-def run(dut, base, dut_isa_spec, dut_platform_spec, work_dir):
+def run(dut, base, dut_isa_spec, dut_platform_spec, work_dir, cntr_args):
     '''
         Entry point for the framework module. This function initializes and sets up the required
         variables for the tests to run.
@@ -165,6 +165,8 @@ def run(dut, base, dut_isa_spec, dut_platform_spec, work_dir):
 
         :param dut_platform_spec: The absolute path to the checked yaml containing
             the DUT platform specification.
+            
+        :param cntr_args: testfile, no_ref_run, no_dut_run
 
         :type dut_platform_spec: str
 
@@ -188,7 +190,7 @@ def run(dut, base, dut_isa_spec, dut_platform_spec, work_dir):
     logger.info("Running Build for Reference")
     base.build(dut_isa_spec, dut_platform_spec)
 
-    results = test.run_tests(dut, base, ispec['hart0'], pspec, work_dir)
+    results = test.run_tests(dut, base, ispec['hart0'], pspec, work_dir, cntr_args)
 
     return results
 

--- a/riscof/framework/main.py
+++ b/riscof/framework/main.py
@@ -184,11 +184,18 @@ def run(dut, base, dut_isa_spec, dut_platform_spec, work_dir, cntr_args):
     #Loading Specs
     ispec = utils.load_yaml(dut_isa_spec)
     pspec = utils.load_yaml(dut_platform_spec)
-
-    logger.info("Running Build for DUT")
-    dut.build(dut_isa_spec, dut_platform_spec)
-    logger.info("Running Build for Reference")
-    base.build(dut_isa_spec, dut_platform_spec)
+    
+    if cntr_args[2]:
+        logger.info("Running Build for DUT")
+        dut.build(dut_isa_spec, dut_platform_spec)
+    elif cntr_args[3]:
+        logger.info("Running Build for Reference")
+        base.build(dut_isa_spec, dut_platform_spec)
+    else:
+        logger.info("Running Build for DUT")
+        dut.build(dut_isa_spec, dut_platform_spec)
+        logger.info("Running Build for Reference")
+        base.build(dut_isa_spec, dut_platform_spec)
 
     results = test.run_tests(dut, base, ispec['hart0'], pspec, work_dir, cntr_args)
 

--- a/riscof/framework/main.py
+++ b/riscof/framework/main.py
@@ -166,7 +166,7 @@ def run(dut, base, dut_isa_spec, dut_platform_spec, work_dir, cntr_args):
         :param dut_platform_spec: The absolute path to the checked yaml containing
             the DUT platform specification.
             
-        :param cntr_args: testfile, no_ref_run, no_dut_run
+        :param cntr_args: dbfile, testfile, no_ref_run, no_dut_run
 
         :type dut_platform_spec: str
 

--- a/riscof/framework/test.py
+++ b/riscof/framework/test.py
@@ -246,8 +246,7 @@ def generate_test_pool(ispec, pspec, workdir, dbfile = None):
     test_pool = []
     test_list = {}
     if dbfile is not None:
-        with open(dbfile,"r") as db_file:
-            db = yaml.load(db_file)
+        db = utils.load_yaml(dbfile)
     else:
         db = utils.load_yaml(constants.framework_db)
     for file in db:
@@ -333,8 +332,7 @@ def run_tests(dut, base, ispec, pspec, work_dir, cntr_args):
             required to generate the report.
     '''
     if cntr_args[1] is not None:
-        with open(cntr_args[1],"r") as tfile:
-            test_list = yaml.load(tfile)
+        test_list = utils.load_yaml(cntr_args[1])
     else:
         test_list, test_pool = generate_test_pool(ispec, pspec, work_dir, cntr_args[0])
     results = []

--- a/riscof/framework/test.py
+++ b/riscof/framework/test.py
@@ -276,9 +276,9 @@ def generate_test_pool(ispec, pspec, workdir, dbfile = None):
                 xlen = '128'
             macros.append("XLEN=" + xlen)
             if re.match(r"^[^(Z,z)]+D.*$",isa):
-                macros.append("FXLEN=64")
+                macros.append("FLEN=64")
             elif re.match(r"^[^(Z,z)]+F.*$",isa):
-                macros.append("FXLEN=32")
+                macros.append("FLEN=32")
             test_pool.append(
                 (file, db[file]['commit_id'], macros, db[file]['isa'],cov_labels))
     logger.info("Selecting Tests.")

--- a/riscof/framework/test.py
+++ b/riscof/framework/test.py
@@ -300,11 +300,13 @@ def generate_test_pool(ispec, pspec, workdir):
 
     with open(os.path.join(workdir,"test_list.yaml"),"w") as tfile:
         yaml.dump(test_list,tfile)
+    with open(os.path.join(workdir,"test_pool.yaml"),"w") as tpfile:
+        yaml.dump(test_pool,tpfile)
 
     return (test_list, test_pool)
 
 
-def run_tests(dut, base, ispec, pspec, work_dir):
+def run_tests(dut, base, ispec, pspec, work_dir, cntr_args):
     '''
         Function to run the tests for the DUT.
 
@@ -315,6 +317,8 @@ def run_tests(dut, base, ispec, pspec, work_dir):
         :param ispec: The isa specifications of the DUT.
 
         :param pspec: The platform specifications of the DUT.
+        
+        :param cntr_args: testfile, no_ref_run, no_dut_run
 
         :type ispec: dict
 
@@ -323,13 +327,29 @@ def run_tests(dut, base, ispec, pspec, work_dir):
         :return: A list of dictionary objects containing the necessary information
             required to generate the report.
     '''
-    test_list, test_pool = generate_test_pool(ispec, pspec, work_dir)
+    if cntr_args[0]:
+        with open(os.path.join(work_dir,"test_pool.yaml"),"r") as tpfile:
+            test_pool = yaml.load(tpfile)
+        with open(os.path.join(work_dir,"test_list.yaml"),"r") as tfile:
+            test_list = yaml.load(tfile)
+    else:
+        test_list, test_pool = generate_test_pool(ispec, pspec, work_dir)
     results = []
-    logger.info("Running Tests on DUT.")
-    dut.runTests(test_list)
-    logger.info("Running Tests on Reference Model.")
-    base.runTests(test_list)
-
+    if cntr_args[1]:
+        logger.info("Running Tests on DUT.")
+        dut.runTests(test_list)
+        logger.info("Tests run on DUT done.")
+        raise SystemExit
+    elif cntr_args[2]:
+        logger.info("Running Tests on Reference Model.")
+        base.runTests(test_list)
+        logger.info("Tests run on Reference done.")
+        raise SystemExit
+    else:
+        logger.info("Running Tests on DUT.")
+        dut.runTests(test_list)
+        logger.info("Running Tests on Reference Model.")
+        base.runTests(test_list)
 
     logger.info("Initiating signature checking.")
     for entry in test_pool:

--- a/riscof/main.py
+++ b/riscof/main.py
@@ -312,10 +312,6 @@ and DUT plugins in the config.ini file')
 
         with open(platform_file, "r") as platfile:
             pspecs = platfile.read()
-            
-        if args.dbfile is not None and args.testfile is not None:
-            logger.error("dbfile and testfile are mutually exclusive arguments")
-            raise SystemExit
         
         cntr_args = [args.dbfile,args.testfile,args.no_ref_run,args.no_dut_run]
         

--- a/riscof/main.py
+++ b/riscof/main.py
@@ -140,7 +140,13 @@ and DUT plugins in the config.ini file')
         if not os.path.exists(work_dir):
             logger.debug('Creating new work directory: ' + work_dir)
             os.mkdir(work_dir)
-        elif not args.testfile:
+        elif args.command=='run':
+            if args.testfile is None:
+                logger.debug('Removing old work directory: ' + work_dir)
+                shutil.rmtree(work_dir)
+                logger.debug('Creating new work directory: ' + work_dir)
+                os.mkdir(work_dir)
+        else:
             logger.debug('Removing old work directory: ' + work_dir)
             shutil.rmtree(work_dir)
             logger.debug('Creating new work directory: ' + work_dir)
@@ -197,7 +203,7 @@ and DUT plugins in the config.ini file')
         isa_file = dut.isa_spec
         platform_file = dut.platform_spec
         
-        if args.testfile:
+        if args.command=='run' and args.testfile is not None:
             isa_file = work_dir+ '/' + (isa_file.rsplit('/', 1)[1]).rsplit('.')[0] + "_checked.yaml"
             platform_file = work_dir+ '/' + (platform_file.rsplit('/', 1)[1]).rsplit('.')[0] + "_checked.yaml"
         else:
@@ -211,8 +217,8 @@ and DUT plugins in the config.ini file')
         isa_specs = utils.load_yaml(isa_file)['hart0']
         platform_specs = utils.load_yaml(platform_file)
 
-    if args.command=='gendb' or args.command=='run' or \
-            args.command=='testlist' or args.command == 'coverage' :
+    if args.command=='gendb' or args.command=='testlist' or \
+            args.command=='coverage' :
         logger.info("Generating database for suite: "+args.suite)
         work_dir = args.work_dir
         constants.suite = args.suite
@@ -223,6 +229,18 @@ and DUT plugins in the config.ini file')
         logger.info('Database File Generated: '+constants.framework_db)
         constants.env = args.env
         logger.info('Env path set to'+constants.env)
+    elif args.command=='run' :
+        if args.dbfile is None and args.testfile is None:
+            logger.info("Generating database for suite: "+args.suite)
+            work_dir = args.work_dir
+            constants.suite = args.suite
+            constants.framework_db = os.path.join(work_dir,"database.yaml")
+            logger.debug('Suite used: '+constants.suite)
+            logger.debug('ENV used: '+ args.env)
+            dbgen.generate()
+            logger.info('Database File Generated: '+constants.framework_db)
+            constants.env = args.env
+            logger.info('Env path set to'+constants.env)
 
     if args.command == 'testlist':
         test_routines.generate_test_pool(isa_specs, platform_specs, work_dir)
@@ -294,8 +312,12 @@ and DUT plugins in the config.ini file')
 
         with open(platform_file, "r") as platfile:
             pspecs = platfile.read()
+            
+        if args.dbfile is not None and args.testfile is not None:
+            logger.error("dbfile and testfile are mutually exclusive arguments")
+            raise SystemExit
         
-        cntr_args = [args.testfile,args.no_ref_run,args.no_dut_run]
+        cntr_args = [args.dbfile,args.testfile,args.no_ref_run,args.no_dut_run]
         
         report_objects = {}
         report_objects['date'] = (datetime.now(

--- a/riscof/main.py
+++ b/riscof/main.py
@@ -141,7 +141,7 @@ and DUT plugins in the config.ini file')
             logger.debug('Creating new work directory: ' + work_dir)
             os.mkdir(work_dir)
         elif args.command=='run':
-            if args.testfile is None:
+            if args.dbfile is None and args.testfile is None:
                 logger.debug('Removing old work directory: ' + work_dir)
                 shutil.rmtree(work_dir)
                 logger.debug('Creating new work directory: ' + work_dir)
@@ -203,7 +203,7 @@ and DUT plugins in the config.ini file')
         isa_file = dut.isa_spec
         platform_file = dut.platform_spec
         
-        if args.command=='run' and args.testfile is not None:
+        if args.command=='run' and (args.testfile is not None or args.dbfile is not None):
             isa_file = work_dir+ '/' + (isa_file.rsplit('/', 1)[1]).rsplit('.')[0] + "_checked.yaml"
             platform_file = work_dir+ '/' + (platform_file.rsplit('/', 1)[1]).rsplit('.')[0] + "_checked.yaml"
         else:
@@ -241,6 +241,13 @@ and DUT plugins in the config.ini file')
             logger.info('Database File Generated: '+constants.framework_db)
             constants.env = args.env
             logger.info('Env path set to'+constants.env)
+        elif args.dbfile is None:
+            constants.suite = args.suite
+            constants.framework_db = os.path.join(work_dir,"database.yaml")
+            constants.env = args.env
+        else:
+            constants.suite = args.suite
+            constants.env = args.env
 
     if args.command == 'testlist':
         test_routines.generate_test_pool(isa_specs, platform_specs, work_dir)

--- a/riscof/utils.py
+++ b/riscof/utils.py
@@ -598,15 +598,16 @@ argument. [Default = latest]',
                         metavar= 'PATH',
                         default=str(pathlib.Path('./riscof_work').absolute())
                         )
-    run.add_argument('--dbfile',
+    run_group = run.add_mutually_exclusive_group()
+    run_group.add_argument('--dbfile',
                         type= lambda p: str(pathlib.Path(p).absolute()),
                         action='store',
-                        help='The Path to the custom suite directory.',
+                        help='The Path to the database file.',
                         metavar= 'PATH')
-    run.add_argument('--testfile',
+    run_group.add_argument('--testfile',
                         type= lambda p: str(pathlib.Path(p).absolute()),
                         action='store',
-                        help='The Path to the custom suite directory.',
+                        help='The Path to the testlist file.',
                         metavar= 'PATH')
     run.add_argument('--no-ref-run',action='store_true',
                      help="Do not run tests on Reference")

--- a/riscof/utils.py
+++ b/riscof/utils.py
@@ -598,8 +598,16 @@ argument. [Default = latest]',
                         metavar= 'PATH',
                         default=str(pathlib.Path('./riscof_work').absolute())
                         )
-    run.add_argument('--testfile',action='store_true',
-                     help="Run tests from already generated testlist file")
+    run.add_argument('--dbfile',
+                        type= lambda p: str(pathlib.Path(p).absolute()),
+                        action='store',
+                        help='The Path to the custom suite directory.',
+                        metavar= 'PATH')
+    run.add_argument('--testfile',
+                        type= lambda p: str(pathlib.Path(p).absolute()),
+                        action='store',
+                        help='The Path to the custom suite directory.',
+                        metavar= 'PATH')
     run.add_argument('--no-ref-run',action='store_true',
                      help="Do not run tests on Reference")
     run.add_argument('--no-dut-run',action='store_true',

--- a/riscof/utils.py
+++ b/riscof/utils.py
@@ -598,6 +598,12 @@ argument. [Default = latest]',
                         metavar= 'PATH',
                         default=str(pathlib.Path('./riscof_work').absolute())
                         )
+    run.add_argument('--testfile',action='store_true',
+                     help="Run tests from already generated testlist file")
+    run.add_argument('--no-ref-run',action='store_true',
+                     help="Do not run tests on Reference")
+    run.add_argument('--no-dut-run',action='store_true',
+                     help="Do not run tests on DUT")
     testlist = subparsers.add_parser('testlist',
                         help='Generate the test list for the given DUT and suite.',formatter_class=SortingHelpFormatter)
     testlist.add_argument('--work-dir',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.21.0
+current_version = 1.21.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup_requirements = [ ]
 test_requirements = [ ]
 
 setup(name="riscof",
-      version='1.21.0',
+      version='1.21.1',
       description="RISC-V Architectural Test Framework",
       long_description=readme + '\n\n',
       classifiers=[


### PR DESCRIPTION
Fix for the issue #1 
- --dbfile argument was not needed because by default testlist is generated and tests are run on both DUT and Target (when using neither --suite or --testfile)
- --testfile is added to directly run tests on the target and reference (assumes the testlist has been correctly generated)
- --no-ref-run is added so that tests do not run on reference and quit before signature comparison
- --no-dut-run is added so that tests do not run on DUT and quit before signature comparison 